### PR TITLE
Switches CitiBikeNYC job to use NYC-specific latlong.

### DIFF
--- a/jobs/citibikenyc.rb
+++ b/jobs/citibikenyc.rb
@@ -2,8 +2,8 @@ require 'dotenv'
 
 Dotenv.load
 
-latitude = ENV['LATITUDE'] || 40.740673
-longitude = ENV['LONGITUDE'] || -73.994808
+latitude = ENV['NYC_LATITUDE'] || 40.740673
+longitude = ENV['NYC_LONGITUDE'] || -73.994808
 lat_long = [latitude, longitude]
 
 SCHEDULER.every '1m' do


### PR DESCRIPTION
A step towards multi-tenancy.

Add the following environment variables for NYC latlong:

NYC_LATITUDE: 40.740151
NYC_LONGITUDE: -73.9948
