### PR TITLE
A widget that pivots can send a text to.

### DIFF
--- a/assets/javascripts/batman-view-filters.coffee
+++ b/assets/javascripts/batman-view-filters.coffee
@@ -1,0 +1,5 @@
+Batman.Filters.dateFormat = (date, format) ->
+  moment(date).format(format)
+
+Batman.Filters.times = (x, y) ->
+  x * y

--- a/dashboards/boulder.erb
+++ b/dashboards/boulder.erb
@@ -4,8 +4,11 @@
     <li data-row="1" data-col="1" data-sizex="1" data-sizey="1">
       <div data-id="pivot_faces_boulder" data-view="PivotFaces"></div>
     </li>
-    <li data-row="1" data-col="2" data-sizex="2" data-sizey="1">
+    <li data-row="1" data-col="2" data-sizex="1" data-sizey="1">
       <div data-id="mantra" data-view="Mantra"></div>
+    </li>
+    <li data-row="1" data-col="3" data-sizex="1" data-sizey="1">
+      <div data-id="pivot_texts_boulder" data-view="PivotTexts" data-title="Messages"></div>
     </li>
 
 

--- a/jobs/pivot_texts.rb
+++ b/jobs/pivot_texts.rb
@@ -1,0 +1,18 @@
+offices_yaml = File.read('offices.yml')
+offices = Offices.load(offices_yaml)
+
+text_message_fetcher = TextMessageFetcher.new(
+  ENV['PIVOTS_TEXTS_URL'],
+  ENV['PIVOTS_TEXTS_BASIC_USERNAME'],
+  ENV['PIVOTS_TEXTS_BASIC_PASSWORD']
+)
+
+SCHEDULER.every '1m', first_in: 0 do
+  pivot_texts_by_location = text_message_fetcher.get.group_by { |pt| pt["pivotLocation"] }
+
+  offices.each do |office|
+    messages = pivot_texts_by_location[office.config["name"]]
+
+    send_event("pivot_texts_#{office.code}", { pivot_texts: messages, phone_number_for_text_messages: ENV['PIVOTS_TEXTS_PHONE_NUMBER'] })
+  end
+end

--- a/lib/text_message_fetcher.rb
+++ b/lib/text_message_fetcher.rb
@@ -1,0 +1,19 @@
+require 'json'
+require 'open-uri'
+
+class TextMessageFetcher
+  def initialize(url, basic_username, basic_password)
+    @uri = URI.parse(url)
+    @req = Net::HTTP::Get.new(@uri)
+    @req.basic_auth(basic_username, basic_password)
+  end
+
+  def get
+    res = Net::HTTP.start(@uri.hostname, @uri.port, use_ssl: @uri.scheme == 'https') { |http|
+      http.request(@req)
+    }
+
+    return JSON.parse(res.body)
+  end
+end
+

--- a/spec/fixtures/pivot_texts.json
+++ b/spec/fixtures/pivot_texts.json
@@ -1,0 +1,18 @@
+[
+  {
+    "pivotId": 1,
+    "pivotLocation": "Boulder",
+    "pivotFirstName": "Jane",
+    "pivotLastName": "Smith",
+    "message": "Hi pivots",
+    "receivedAt": 1435347799
+  },
+  {
+    "pivotId": 2,
+    "pivotLocation": "Denver",
+    "pivotFirstName": "John",
+    "pivotLastName": "Denver",
+    "message": ":)",
+    "receivedAt": 1435347799
+  }
+]

--- a/spec/lib/text_message_fetcher_spec.rb
+++ b/spec/lib/text_message_fetcher_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require 'webmock'
+include WebMock::API
+
+describe TextMessageFetcher do
+  let(:pivot_texts_url) {'http://pivot-texts/texts/all'}
+  let(:basic_username) {'test-un'}
+  let(:basic_password) {'test-pw'}
+
+  before(:each) do
+    stub_request(:get, "http://test-un:test-pw@pivot-texts/texts/all").to_return(:body => File.read('spec/fixtures/pivot_texts.json'))
+  end
+
+  describe '#[]' do
+    let(:fetcher) { TextMessageFetcher.new(pivot_texts_url, basic_username, basic_password) }
+
+    it 'returns all text messages' do
+      texts = fetcher.get
+      expect(texts.size).to eq 2
+
+      first_text = texts.first
+      expect(first_text["pivotId"]).to eq 1
+      expect(first_text["pivotLocation"]).to eq "Boulder"
+      expect(first_text["pivotFirstName"]).to eq "Jane"
+      expect(first_text["pivotLastName"]).to eq "Smith"
+      expect(first_text["message"]).to eq "Hi pivots"
+      expect(first_text["receivedAt"]).to eq 1435347799
+    end
+  end
+end

--- a/widgets/pivot_texts/pivot_texts.coffee
+++ b/widgets/pivot_texts/pivot_texts.coffee
@@ -1,0 +1,13 @@
+class Dashing.PivotTexts extends Dashing.Widget
+  ready: =>
+    @currentRandomMessageIdx = 0
+    setInterval(@rotate, 8000)
+    @rotate()
+
+  onData: (data) =>
+    @set('phoneNumberForTextMessages', data.phone_number_for_text_messages)
+    @rotate()
+
+  rotate: =>
+    @currentRandomMessageIdx = ((@currentRandomMessageIdx + 1) % @get('pivot_texts').length)
+    @set('item', @get('pivot_texts')[@currentRandomMessageIdx])

--- a/widgets/pivot_texts/pivot_texts.html
+++ b/widgets/pivot_texts/pivot_texts.html
@@ -1,0 +1,18 @@
+<div class="pivot-texts-container">
+    <div data-showif="item">
+        <div class="title" data-bind="item.message"></div>
+
+        <div class="name">
+            <span class="first" data-bind="item.pivotFirstName"></span>
+            <span class="last" data-bind="item.pivotLastName"></span>
+            @
+            <span class="last" data-bind="item.receivedAt | times 1000 | dateFormat 'h:m a'"></span>
+        </div>
+    </div>
+
+    <div data-hideif="item">
+        <div class="title"">No messages</div>
+    </div>
+</div>
+
+<p class="message-reminder">Send a text message to <span data-bind="phoneNumberForTextMessages"></span></p>

--- a/widgets/pivot_texts/pivot_texts.scss
+++ b/widgets/pivot_texts/pivot_texts.scss
@@ -1,0 +1,24 @@
+.widget-pivot-texts {
+  background-color: #dcdc00;
+  color: #234233;
+
+  .name {
+    font-weight: bold;
+    padding-top: 50px;
+    font-size: 0.8em;
+  }
+
+  .title {
+    font-size: 1.25em;
+    font-weight: bold;
+  }
+}
+
+.message-reminder {
+  font-size: 15px;
+  position: absolute;
+  bottom: 12px;
+  left: 0;
+  right: 0;
+  color: #639b8b;
+}


### PR DESCRIPTION
- The pivot's phone number must be in the pivots app
- requires 4 env variables:

PIVOTS_TEXTS_PHONE_NUMBER - for display purposes only.
PIVOTS_TEXTS_URL - the pivot-texts api address
PIVOTS_TEXTS_BASIC_USERNAME - the pivot-texts api server basic auth username
PIVOTS_TEXTS_BASIC_PASSWORD - the pivot-texts api server basic auth password